### PR TITLE
Player data

### DIFF
--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -1130,9 +1130,45 @@
       "assist_per_game": 6.0,
       "steals_per_game": 1.30, 
       "blocks_per_game": 0.20
+    }, 
+    {
+      "name": "Bradley Beal",
+      "team": "Washington Wizard", 
+      "games_played": 49, 
+      "points_per_game": 24.6, 
+      "field_goal_percentage": 47,
+      "three_point_percentage": 35, 
+      "free_throw_percentage": 79,
+      "rebounds_per_game": 5.1,
+      "assist_per_game": 5.0,
+      "steals_per_game": 1.41, 
+      "blocks_per_game": 0.82
+    }, 
+    {
+      "name": "John Wall",
+      "team": "Washington Wizard", 
+      "games_played": 32, 
+      "points_per_game": 20.7, 
+      "field_goal_percentage": 44,
+      "three_point_percentage": 30, 
+      "free_throw_percentage": 70,
+      "rebounds_per_game": 3.6,
+      "assist_per_game": 8.7,
+      "steals_per_game": 1.53, 
+      "blocks_per_game": 0.91
+    }, 
+    {
+      "name": "Trevor Ariza",
+      "team": "Washington Wizard", 
+      "games_played": 19, 
+      "points_per_game": 15.2, 
+      "field_goal_percentage": 37,
+      "three_point_percentage": 31, 
+      "free_throw_percentage": 81,
+      "rebounds_per_game": 6.0,
+      "assist_per_game": 4.3,
+      "steals_per_game": 1.63, 
+      "blocks_per_game": 0.16
     }
-
-    
-   
   ]
 }

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -935,6 +935,45 @@
       "assist_per_game": 2.0,
       "steals_per_game": 0.79, 
       "blocks_per_game": 0.98
+    }, 
+    {
+      "name": "Damian Lillard",
+      "team": "Portland Trail Blazers", 
+      "games_played": 50, 
+      "points_per_game": 26.2, 
+      "field_goal_percentage": 45,
+      "three_point_percentage": 37, 
+      "free_throw_percentage": 91,
+      "rebounds_per_game": 4.5,
+      "assist_per_game": 6.2,
+      "steals_per_game": 1.06, 
+      "blocks_per_game": 0.50
+    }, 
+    {
+      "name": "CJ McCollum",
+      "team": "Portland Trail Blazers", 
+      "games_played": 50, 
+      "points_per_game": 20.8, 
+      "field_goal_percentage": 46,
+      "three_point_percentage": 35, 
+      "free_throw_percentage": 83,
+      "rebounds_per_game": 3.9,
+      "assist_per_game": 2.8,
+      "steals_per_game": 0.80, 
+      "blocks_per_game": 0.34
+    }, 
+    {
+      "name": "Jusuf Nurkic",
+      "team": "Portland Trail Blazers", 
+      "games_played": 51, 
+      "points_per_game": 15.2, 
+      "field_goal_percentage": 50,
+      "three_point_percentage": 12, 
+      "free_throw_percentage": 75,
+      "rebounds_per_game": 10.4,
+      "assist_per_game": 3.2,
+      "steals_per_game": 1.08, 
+      "blocks_per_game": 1.57
     }
     
    

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -545,6 +545,45 @@
       "assist_per_game": 2.9,
       "steals_per_game": 0.64, 
       "blocks_per_game": 0.64
+    }, 
+    {
+      "name": "Mike Conley",
+      "team": "Memphis Grizzlies", 
+      "games_played": 50, 
+      "points_per_game": 20.1, 
+      "field_goal_percentage": 43,
+      "three_point_percentage": 35, 
+      "free_throw_percentage": 84,
+      "rebounds_per_game": 3.3,
+      "assist_per_game": 6.3,
+      "steals_per_game": 1.36, 
+      "blocks_per_game": 0.34
+    }, 
+    {
+      "name": "Marc Gasol",
+      "team": "Memphis Grizzlies", 
+      "games_played": 50, 
+      "points_per_game": 15.7, 
+      "field_goal_percentage": 44,
+      "three_point_percentage": 35, 
+      "free_throw_percentage": 76,
+      "rebounds_per_game": 8.7,
+      "assist_per_game": 4.7,
+      "steals_per_game": 1.18, 
+      "blocks_per_game": 1.26
+    }, 
+    {
+      "name": "Jaren Jackson Jr.",
+      "team": "Memphis Grizzlies", 
+      "games_played": 51, 
+      "points_per_game": 13.5, 
+      "field_goal_percentage": 51,
+      "three_point_percentage": 32, 
+      "free_throw_percentage": 78,
+      "rebounds_per_game": 4.6,
+      "assist_per_game": 1.1,
+      "steals_per_game": 0.92, 
+      "blocks_per_game": 1.49
     }
     
    

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -1052,6 +1052,45 @@
       "assist_per_game": 2.5,
       "steals_per_game": 0.88, 
       "blocks_per_game": 0.61
+    }, 
+    {
+      "name": "Kawhi Leonard",
+      "team": "Toronto Raptors", 
+      "games_played": 38, 
+      "points_per_game": 27.9, 
+      "field_goal_percentage": 50,
+      "three_point_percentage": 37, 
+      "free_throw_percentage": 86,
+      "rebounds_per_game": 7.9,
+      "assist_per_game": 3.2,
+      "steals_per_game": 1.89, 
+      "blocks_per_game": 0.50
+    }, 
+    {
+      "name": "Serge Ibaka",
+      "team": "Toronto Raptors", 
+      "games_played": 48, 
+      "points_per_game": 16.1, 
+      "field_goal_percentage": 52,
+      "three_point_percentage": 27, 
+      "free_throw_percentage": 78,
+      "rebounds_per_game": 7.6,
+      "assist_per_game": 1.4,
+      "steals_per_game": 0.48, 
+      "blocks_per_game": 1.33
+    }, 
+    {
+      "name": "Pascal Siakam",
+      "team": "Toronto Raptors", 
+      "games_played": 51, 
+      "points_per_game": 15.2, 
+      "field_goal_percentage": 56,
+      "three_point_percentage": 32, 
+      "free_throw_percentage": 80,
+      "rebounds_per_game": 7.0,
+      "assist_per_game": 2.9,
+      "steals_per_game": 0.96, 
+      "blocks_per_game": 0.67
     }
 
     

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -1,0 +1,17 @@
+{
+  "players": [
+    {
+      "name": 
+      "team": 
+      "games_played":
+      "points_per_game": 
+      "field_goal_percentage": 
+      "three_point_percentage": 
+      "free_throw_percentage":
+      "rebounds_per_game": 
+      "assist_per_game": 
+      "steals_per_game": 
+      "blocks_per_game": 
+    }
+  ]
+}

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -1014,6 +1014,45 @@
       "steals_per_game": 1.00, 
       "blocks_per_game": 0.18
     },
+    {
+      "name": "DeMar DeRozan",
+      "team": "San Antonio Spurs", 
+      "games_played": 48, 
+      "points_per_game": 21.5, 
+      "field_goal_percentage": 46,
+      "three_point_percentage": 17, 
+      "free_throw_percentage": 82,
+      "rebounds_per_game": 6.2,
+      "assist_per_game": 6.3,
+      "steals_per_game": 1.06, 
+      "blocks_per_game": 0.50
+    },
+    {
+      "name": "LaMarcus Aldridge",
+      "team": "San Antonio Spurs", 
+      "games_played": 51, 
+      "points_per_game": 20.9, 
+      "field_goal_percentage": 51,
+      "three_point_percentage": 21, 
+      "free_throw_percentage": 85,
+      "rebounds_per_game": 8.6,
+      "assist_per_game": 2.6,
+      "steals_per_game": 0.55, 
+      "blocks_per_game": 1.24
+    }, 
+    {
+      "name": "Rudy Gay",
+      "team": "San Antonio Spurs", 
+      "games_played": 41, 
+      "points_per_game": 14.4, 
+      "field_goal_percentage": 52,
+      "three_point_percentage": 40, 
+      "free_throw_percentage": 86,
+      "rebounds_per_game": 6.5,
+      "assist_per_game": 2.5,
+      "steals_per_game": 0.88, 
+      "blocks_per_game": 0.61
+    }
 
     
    

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -740,6 +740,45 @@
       "assist_per_game": 3.0,
       "steals_per_game": 0.60, 
       "blocks_per_game": 0.60
+    }, 
+    {
+      "name": "Tim Hardaway Jr.",
+      "team": "New York Knicks", 
+      "games_played": 45, 
+      "points_per_game": 19.4, 
+      "field_goal_percentage": 39,
+      "three_point_percentage": 34, 
+      "free_throw_percentage": 85,
+      "rebounds_per_game": 3.5,
+      "assist_per_game": 2.6,
+      "steals_per_game": 0.91, 
+      "blocks_per_game": 0.13
+    }, 
+    {
+      "name": "Emmanuel Mudiay",
+      "team": "New York Knicks", 
+      "games_played": 39, 
+      "points_per_game": 14.7, 
+      "field_goal_percentage": 45,
+      "three_point_percentage": 30, 
+      "free_throw_percentage": 76,
+      "rebounds_per_game": 3.1,
+      "assist_per_game": 3.9,
+      "steals_per_game": 0.79, 
+      "blocks_per_game": 0.33
+    }, 
+    {
+      "name": "Enes Kanter",
+      "team": "New York Knicks", 
+      "games_played": 42, 
+      "points_per_game": 14.4, 
+      "field_goal_percentage": 54,
+      "three_point_percentage": 33, 
+      "free_throw_percentage": 82,
+      "rebounds_per_game": 10.8,
+      "assist_per_game": 2.0,
+      "steals_per_game": 0.43, 
+      "blocks_per_game": 0.40
     }
     
    

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -974,7 +974,47 @@
       "assist_per_game": 3.2,
       "steals_per_game": 1.08, 
       "blocks_per_game": 1.57
-    }
+    }, 
+    {
+      "name": "Buddy Heild",
+      "team": "Sacramento Kings", 
+      "games_played": 50, 
+      "points_per_game": 20.2, 
+      "field_goal_percentage": 47,
+      "three_point_percentage": 45, 
+      "free_throw_percentage": 86,
+      "rebounds_per_game": 4.9,
+      "assist_per_game": 2.3,
+      "steals_per_game": 0.50, 
+      "blocks_per_game": 0.34
+    },
+    {
+      "name": "De'Aaron Fox",
+      "team": "Sacramento Kings", 
+      "games_played": 49, 
+      "points_per_game": 17.6, 
+      "field_goal_percentage": 46,
+      "three_point_percentage": 37, 
+      "free_throw_percentage": 73,
+      "rebounds_per_game": 3.7,
+      "assist_per_game": 7.2,
+      "steals_per_game": 1.73, 
+      "blocks_per_game": 0.51
+    }, 
+    {
+      "name": "Bogdan Bogdanovic",
+      "team": "Sacramento Kings", 
+      "games_played": 38, 
+      "points_per_game": 15.2, 
+      "field_goal_percentage": 43,
+      "three_point_percentage": 36, 
+      "free_throw_percentage": 81,
+      "rebounds_per_game": 3.6,
+      "assist_per_game": 4.1,
+      "steals_per_game": 1.00, 
+      "blocks_per_game": 0.18
+    },
+
     
    
   ]

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -662,6 +662,45 @@
       "assist_per_game": 3.3,
       "steals_per_game": 0.73, 
       "blocks_per_game": 0.24
+    },
+    {
+      "name": "Karl-Anthony Towns",
+      "team": "Minnesota Timberwolves", 
+      "games_played": 50, 
+      "points_per_game": 22.8, 
+      "field_goal_percentage": 50,
+      "three_point_percentage": 38, 
+      "free_throw_percentage": 85,
+      "rebounds_per_game": 12.2,
+      "assist_per_game": 3.1,
+      "steals_per_game": 0.96, 
+      "blocks_per_game": 1.90
+    }, 
+    {
+      "name": "Derrick Rose",
+      "team": "Minnesota Timberwolves", 
+      "games_played": 38, 
+      "points_per_game": 18.6, 
+      "field_goal_percentage": 48,
+      "three_point_percentage": 41, 
+      "free_throw_percentage": 85,
+      "rebounds_per_game": 2.8,
+      "assist_per_game": 4.7,
+      "steals_per_game": 0.63, 
+      "blocks_per_game": 0.26
+    }, 
+    {
+      "name": "Andrew Wiggins",
+      "team": "Minnesota Timberwolves", 
+      "games_played": 46, 
+      "points_per_game": 18.1, 
+      "field_goal_percentage": 40,
+      "three_point_percentage": 34, 
+      "free_throw_percentage": 72,
+      "rebounds_per_game": 4.6,
+      "assist_per_game": 2.3,
+      "steals_per_game": 1.09, 
+      "blocks_per_game": 0.52
     }
     
    

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -701,6 +701,45 @@
       "assist_per_game": 2.3,
       "steals_per_game": 1.09, 
       "blocks_per_game": 0.52
+    },
+    {
+      "name": "Anthony Davis",
+      "team": "New Orleans Pelicans", 
+      "games_played": 41, 
+      "points_per_game": 29.3, 
+      "field_goal_percentage": 50,
+      "three_point_percentage": 32, 
+      "free_throw_percentage": 81,
+      "rebounds_per_game": 13.3,
+      "assist_per_game": 4.4,
+      "steals_per_game": 1.71, 
+      "blocks_per_game": 2.56
+    }, 
+    {
+      "name": "Jrue Holiday",
+      "team": "New Orleans Pelicans", 
+      "games_played": 50, 
+      "points_per_game": 21.2, 
+      "field_goal_percentage": 48,
+      "three_point_percentage": 33, 
+      "free_throw_percentage": 75,
+      "rebounds_per_game": 4.9,
+      "assist_per_game": 8.1,
+      "steals_per_game": 1.66, 
+      "blocks_per_game": 0.76
+    }, 
+    {
+      "name": "Julius Randle",
+      "team": "New Orleans Pelicans", 
+      "games_played": 47, 
+      "points_per_game": 19.9, 
+      "field_goal_percentage": 54,
+      "three_point_percentage": 31, 
+      "free_throw_percentage": 74,
+      "rebounds_per_game": 9.3,
+      "assist_per_game": 3.0,
+      "steals_per_game": 0.60, 
+      "blocks_per_game": 0.60
     }
     
    

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -467,6 +467,45 @@
       "assist_per_game": 2.8,
       "steals_per_game": 0.64, 
       "blocks_per_game": 0.47
+    }, 
+    {
+      "name": "Tobias Harris",
+      "team": "Los Angeles Clippers", 
+      "games_played": 51, 
+      "points_per_game": 21.2, 
+      "field_goal_percentage": 50,
+      "three_point_percentage": 43, 
+      "free_throw_percentage": 88,
+      "rebounds_per_game": 7.9,
+      "assist_per_game": 2.6,
+      "steals_per_game": 0.76, 
+      "blocks_per_game": 0.45
+    }, 
+    {
+      "name": "Danilo Gallinari",
+      "team": "Los Angeles Clippers", 
+      "games_played": 44, 
+      "points_per_game": 19.0, 
+      "field_goal_percentage": 45,
+      "three_point_percentage": 45, 
+      "free_throw_percentage": 91,
+      "rebounds_per_game": 6.0,
+      "assist_per_game": 2.5,
+      "steals_per_game": 0.73, 
+      "blocks_per_game": 0.27
+    }, 
+    {
+      "name": "Lou Williams",
+      "team": "Los Angeles Clippers", 
+      "games_played": 45, 
+      "points_per_game": 18.7, 
+      "field_goal_percentage": 41,
+      "three_point_percentage": 35, 
+      "free_throw_percentage": 90,
+      "rebounds_per_game": 3.0,
+      "assist_per_game": 5.2,
+      "steals_per_game": 0.64, 
+      "blocks_per_game": 0.13
     }
     
    

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -233,6 +233,45 @@
       "assist_per_game": 2.8,
       "steals_per_game": 0.51, 
       "blocks_per_game": 0.06
+    }, 
+    {
+      "name": "Luka Doncic",
+      "team": "Dallas Mavericks", 
+      "games_played": 48, 
+      "points_per_game": 20.5, 
+      "field_goal_percentage": 43,
+      "three_point_percentage": 35, 
+      "free_throw_percentage": 73,
+      "rebounds_per_game": 6.9,
+      "assist_per_game": 5.4,
+      "steals_per_game": 1.15, 
+      "blocks_per_game": 0.29
+    }, 
+    {
+      "name": "Harrison Barners",
+      "team": "Dallas Mavericks", 
+      "games_played": 45, 
+      "points_per_game": 17.6, 
+      "field_goal_percentage": 40,
+      "three_point_percentage": 39, 
+      "free_throw_percentage": 83,
+      "rebounds_per_game": 4.2,
+      "assist_per_game": 1.2,
+      "steals_per_game": 0.73, 
+      "blocks_per_game": 0.22
+    }, 
+    {
+      "name": "Wesley Matthews",
+      "team": "Dallas Mavericks", 
+      "games_played": 43, 
+      "points_per_game": 13.0, 
+      "field_goal_percentage": 41,
+      "three_point_percentage": 37, 
+      "free_throw_percentage": 79,
+      "rebounds_per_game": 2.3,
+      "assist_per_game": 2.3,
+      "steals_per_game": 0.77, 
+      "blocks_per_game": 0.28
     }
    
   ]

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -506,6 +506,45 @@
       "assist_per_game": 5.2,
       "steals_per_game": 0.64, 
       "blocks_per_game": 0.13
+    }, 
+    {
+      "name": "Lebron James",
+      "team": "Los Angeles Lakers", 
+      "games_played": 34, 
+      "points_per_game": 27.3, 
+      "field_goal_percentage": 52,
+      "three_point_percentage": 36, 
+      "free_throw_percentage": 68,
+      "rebounds_per_game": 8.3,
+      "assist_per_game": 7.1,
+      "steals_per_game": 1.29, 
+      "blocks_per_game": 0.71
+    },
+    {
+      "name": "Kyle Kuzma",
+      "team": "Los Angeles Lakers", 
+      "games_played": 47, 
+      "points_per_game": 19.1, 
+      "field_goal_percentage": 46,
+      "three_point_percentage": 30, 
+      "free_throw_percentage": 76,
+      "rebounds_per_game": 5.9,
+      "assist_per_game": 2.5,
+      "steals_per_game": 0.66, 
+      "blocks_per_game": 0.38
+    }, 
+    {
+      "name": "Brandon Ingram",
+      "team": "Los Angeles Lakers", 
+      "games_played": 39, 
+      "points_per_game": 16.6, 
+      "field_goal_percentage": 47,
+      "three_point_percentage": 30, 
+      "free_throw_percentage": 63,
+      "rebounds_per_game": 4.9,
+      "assist_per_game": 2.9,
+      "steals_per_game": 0.64, 
+      "blocks_per_game": 0.64
     }
     
    

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -779,6 +779,45 @@
       "assist_per_game": 2.0,
       "steals_per_game": 0.43, 
       "blocks_per_game": 0.40
+    }, 
+    {
+      "name": "Paul George",
+      "team": "Oklahoma City Thunder", 
+      "games_played": 48, 
+      "points_per_game": 27.1, 
+      "field_goal_percentage": 45,
+      "three_point_percentage": 40, 
+      "free_throw_percentage": 83,
+      "rebounds_per_game": 8.1,
+      "assist_per_game": 4.0,
+      "steals_per_game": 2.31, 
+      "blocks_per_game": 0.50
+    },
+    {
+      "name": "Russell Westbrook",
+      "team": "Oklahoma City Thunder", 
+      "games_played": 41, 
+      "points_per_game": 21.6, 
+      "field_goal_percentage": 41,
+      "three_point_percentage": 24, 
+      "free_throw_percentage": 65,
+      "rebounds_per_game": 10.8,
+      "assist_per_game": 10.7,
+      "steals_per_game": 2.34, 
+      "blocks_per_game": 0.32
+    }, 
+    {
+      "name": "Steven Adams",
+      "team": "Oklahoma City Thunder", 
+      "games_played": 48, 
+      "points_per_game": 15.4, 
+      "field_goal_percentage": 61,
+      "three_point_percentage": 0, 
+      "free_throw_percentage": 56,
+      "rebounds_per_game": 10.0,
+      "assist_per_game": 1.8,
+      "steals_per_game": 1.48, 
+      "blocks_per_game": 0.77
     }
     
    

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -155,6 +155,45 @@
       "assist_per_game": 1.3,
       "steals_per_game": 0.90, 
       "blocks_per_game": 0.73
+    }, 
+    {
+      "name": "Zach Lavine",
+      "team": "Chicago Bulls", 
+      "games_played": 44, 
+      "points_per_game": 22.9, 
+      "field_goal_percentage": 45,
+      "three_point_percentage": 34, 
+      "free_throw_percentage": 87,
+      "rebounds_per_game": 4.4,
+      "assist_per_game": 4.2,
+      "steals_per_game": 0.95, 
+      "blocks_per_game": 0.39
+    }, 
+    {
+      "name": "Lauri Markkanen",
+      "team": "Chicago Bulls", 
+      "games_played": 27, 
+      "points_per_game": 17.1, 
+      "field_goal_percentage": 43,
+      "three_point_percentage": 39, 
+      "free_throw_percentage": 84,
+      "rebounds_per_game": 7.4,
+      "assist_per_game": 0.9,
+      "steals_per_game": 0.89, 
+      "blocks_per_game": 0.81
+    }, 
+    {
+      "name": "Jabari Parker",
+      "team": "Chicago Bulls", 
+      "games_played": 37, 
+      "points_per_game": 14.4, 
+      "field_goal_percentage": 46,
+      "three_point_percentage": 32, 
+      "free_throw_percentage": 74,
+      "rebounds_per_game": 6.2,
+      "assist_per_game": 2.2,
+      "steals_per_game": 0.57, 
+      "blocks_per_game": 0.32
     }
    
   ]

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -1091,6 +1091,45 @@
       "assist_per_game": 2.9,
       "steals_per_game": 0.96, 
       "blocks_per_game": 0.67
+    }, 
+    {
+      "name": "Donovan Mitchell",
+      "team": "Utah Jazz", 
+      "games_played": 47, 
+      "points_per_game": 22.5, 
+      "field_goal_percentage": 42,
+      "three_point_percentage": 33, 
+      "free_throw_percentage": 79,
+      "rebounds_per_game": 3.8,
+      "assist_per_game": 4.0,
+      "steals_per_game": 1.57, 
+      "blocks_per_game": 0.38
+    }, 
+    {
+      "name": "Rudy Gobert",
+      "team": "Utah Jazz", 
+      "games_played": 51, 
+      "points_per_game": 15.0, 
+      "field_goal_percentage": 64,
+      "three_point_percentage": 0, 
+      "free_throw_percentage": 65,
+      "rebounds_per_game": 12.9,
+      "assist_per_game": 2.2,
+      "steals_per_game": 0.94, 
+      "blocks_per_game": 2.16
+    }, 
+    {
+      "name": "Ricky Rubio",
+      "team": "Utah Jazz", 
+      "games_played": 44, 
+      "points_per_game": 12.8, 
+      "field_goal_percentage": 41,
+      "three_point_percentage": 32, 
+      "free_throw_percentage": 85,
+      "rebounds_per_game": 3.5,
+      "assist_per_game": 6.0,
+      "steals_per_game": 1.30, 
+      "blocks_per_game": 0.20
     }
 
     

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -350,6 +350,45 @@
       "assist_per_game": 4.2,
       "steals_per_game": 0.67, 
       "blocks_per_game": 0.13
+    }, 
+    {
+      "name": "Stephen Curry",
+      "team": "Golden State Warriors", 
+      "games_played": 39, 
+      "points_per_game": 29.3, 
+      "field_goal_percentage": 49,
+      "three_point_percentage": 45, 
+      "free_throw_percentage": 93,
+      "rebounds_per_game": 5.1,
+      "assist_per_game": 5.4,
+      "steals_per_game": 1.18, 
+      "blocks_per_game": 0.36
+    }, 
+    {
+      "name": "Kevin Durant",
+      "team": "Golden State Warriors", 
+      "games_played": 50, 
+      "points_per_game": 27.7, 
+      "field_goal_percentage": 50,
+      "three_point_percentage": 38, 
+      "free_throw_percentage": 91,
+      "rebounds_per_game": 7.2,
+      "assist_per_game": 5.9,
+      "steals_per_game": 0.82, 
+      "blocks_per_game": 1.16
+    }, 
+    {
+      "name": "Klay Thompson",
+      "team": "Golden State Warriors", 
+      "games_played": 50, 
+      "points_per_game": 21.7, 
+      "field_goal_percentage": 46,
+      "three_point_percentage": 38, 
+      "free_throw_percentage": 80,
+      "rebounds_per_game": 4.0,
+      "assist_per_game": 2.0,
+      "steals_per_game": 1.18, 
+      "blocks_per_game": 0.64
     }
    
   ]

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -857,6 +857,45 @@
       "assist_per_game": 3.5,
       "steals_per_game": 0.88, 
       "blocks_per_game": 0.16
+    }, 
+    {
+      "name": "Joel Embiid",
+      "team": "Philadelphia Sixers", 
+      "games_played": 46, 
+      "points_per_game": 27.2, 
+      "field_goal_percentage": 49,
+      "three_point_percentage": 31, 
+      "free_throw_percentage": 80,
+      "rebounds_per_game": 13.3,
+      "assist_per_game": 3.5,
+      "steals_per_game": 0.57, 
+      "blocks_per_game": 1.96
+    }, 
+    {
+      "name": "Jimmy Buter",
+      "team": "Philadelphia Sixers", 
+      "games_played": 28, 
+      "points_per_game": 19.0, 
+      "field_goal_percentage": 47,
+      "three_point_percentage": 38, 
+      "free_throw_percentage": 87,
+      "rebounds_per_game": 4.8,
+      "assist_per_game": 3.5,
+      "steals_per_game": 1.90, 
+      "blocks_per_game": 0.50
+    }, 
+    {
+      "name": "JJ Redick",
+      "team": "Philadelphia Sixers", 
+      "games_played": 48, 
+      "points_per_game": 18.5, 
+      "field_goal_percentage": 45,
+      "three_point_percentage": 38, 
+      "free_throw_percentage": 90,
+      "rebounds_per_game": 2.2,
+      "assist_per_game": 2.8,
+      "steals_per_game": 0.40, 
+      "blocks_per_game": 0.21
     }
     
    

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -818,6 +818,45 @@
       "assist_per_game": 1.8,
       "steals_per_game": 1.48, 
       "blocks_per_game": 0.77
+    }, 
+    {
+      "name": "Nikola Vucevic",
+      "team": "Orlando Magic", 
+      "games_played": 49, 
+      "points_per_game": 20.6, 
+      "field_goal_percentage": 51,
+      "three_point_percentage": 37, 
+      "free_throw_percentage": 77,
+      "rebounds_per_game": 12.0,
+      "assist_per_game": 3.8,
+      "steals_per_game": 0.98, 
+      "blocks_per_game": 1.14
+    }, 
+    {
+      "name": "Aaron Gordon",
+      "team": "Orlando Magic", 
+      "games_played": 46, 
+      "points_per_game": 15.9, 
+      "field_goal_percentage": 45,
+      "three_point_percentage": 35, 
+      "free_throw_percentage": 72,
+      "rebounds_per_game": 7.7,
+      "assist_per_game": 3.4,
+      "steals_per_game": 0.74, 
+      "blocks_per_game": 0.67
+    }, 
+    {
+      "name": "Evan Fournier",
+      "team": "Orlando Magic", 
+      "games_played": 49, 
+      "points_per_game": 14.8, 
+      "field_goal_percentage": 42,
+      "three_point_percentage": 32, 
+      "free_throw_percentage": 78,
+      "rebounds_per_game": 3.0,
+      "assist_per_game": 3.5,
+      "steals_per_game": 0.88, 
+      "blocks_per_game": 0.16
     }
     
    

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -194,6 +194,45 @@
       "assist_per_game": 2.2,
       "steals_per_game": 0.57, 
       "blocks_per_game": 0.32
+    }, 
+    {
+      "name": "Kevin Love",
+      "team": "Cleveland Cavaliers", 
+      "games_played": 4, 
+      "points_per_game": 19.0, 
+      "field_goal_percentage": 32,
+      "three_point_percentage": 29, 
+      "free_throw_percentage": 82,
+      "rebounds_per_game": 13.5,
+      "assist_per_game": 3.5,
+      "steals_per_game": 0.25, 
+      "blocks_per_game": 0.25
+    }, 
+    {
+      "name": "Jordan Clarkson",
+      "team": "Cleveland Cavaliers", 
+      "games_played": 50, 
+      "points_per_game": 16.5, 
+      "field_goal_percentage": 45,
+      "three_point_percentage": 33, 
+      "free_throw_percentage": 85,
+      "rebounds_per_game": 3.3,
+      "assist_per_game": 2.3,
+      "steals_per_game": 0.74, 
+      "blocks_per_game": 0.18
+    }, 
+    {
+      "name": "Collin Sexton",
+      "team": "Cleveland Cavaliers", 
+      "games_played": 51, 
+      "points_per_game": 14.4, 
+      "field_goal_percentage": 41,
+      "three_point_percentage": 40, 
+      "free_throw_percentage": 85,
+      "rebounds_per_game": 3.0,
+      "assist_per_game": 2.8,
+      "steals_per_game": 0.51, 
+      "blocks_per_game": 0.06
     }
    
   ]

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -272,6 +272,45 @@
       "assist_per_game": 2.3,
       "steals_per_game": 0.77, 
       "blocks_per_game": 0.28
+    }, 
+    {
+      "name": "Nikola Jokic",
+      "team": "Denver Nuggets", 
+      "games_played": 48, 
+      "points_per_game": 20.1, 
+      "field_goal_percentage": 50,
+      "three_point_percentage": 31, 
+      "free_throw_percentage": 85,
+      "rebounds_per_game": 10.3,
+      "assist_per_game": 7.6,
+      "steals_per_game": 1.40, 
+      "blocks_per_game": 0.69
+    }, 
+    {
+      "name": "Jamal Murray",
+      "team": "Denver Nuggets", 
+      "games_played": 47, 
+      "points_per_game": 18.5, 
+      "field_goal_percentage": 43,
+      "three_point_percentage": 36, 
+      "free_throw_percentage": 84,
+      "rebounds_per_game": 4.4,
+      "assist_per_game": 4.9,
+      "steals_per_game": 0.79, 
+      "blocks_per_game": 0.38
+    }, 
+    {
+      "name": "Gary Harris",
+      "team": "Denver Nuggets", 
+      "games_played": 31, 
+      "points_per_game": 15.0, 
+      "field_goal_percentage": 43,
+      "three_point_percentage": 32, 
+      "free_throw_percentage": 82,
+      "rebounds_per_game": 3.1,
+      "assist_per_game": 2.7,
+      "steals_per_game": 0.90, 
+      "blocks_per_game": 0.42
     }
    
   ]

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -623,6 +623,45 @@
       "assist_per_game": 4.3,
       "steals_per_game": 0.62, 
       "blocks_per_game": 0.46
+    }, 
+    {
+      "name": "Giannis Antetokounmpo",
+      "team": "Milwaukee Bucks", 
+      "games_played": 45, 
+      "points_per_game": 26.6, 
+      "field_goal_percentage": 57,
+      "three_point_percentage": 20, 
+      "free_throw_percentage": 70,
+      "rebounds_per_game": 12.7,
+      "assist_per_game": 5.8,
+      "steals_per_game": 1.38, 
+      "blocks_per_game": 1.42
+    }, 
+    {
+      "name": "Khris Middleton",
+      "team": "Milwaukee Bucks", 
+      "games_played": 46, 
+      "points_per_game": 17.4, 
+      "field_goal_percentage": 43,
+      "three_point_percentage": 37, 
+      "free_throw_percentage": 84,
+      "rebounds_per_game": 5.7,
+      "assist_per_game": 4.1,
+      "steals_per_game": 1.11, 
+      "blocks_per_game": 0.09
+    }, 
+    {
+      "name": "Malcolm Brogdon",
+      "team": "Milwaukee Bucks", 
+      "games_played": 45, 
+      "points_per_game": 15.8, 
+      "field_goal_percentage": 51,
+      "three_point_percentage": 41, 
+      "free_throw_percentage": 95,
+      "rebounds_per_game": 4.6,
+      "assist_per_game": 3.3,
+      "steals_per_game": 0.73, 
+      "blocks_per_game": 0.24
     }
     
    

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -311,6 +311,45 @@
       "assist_per_game": 2.7,
       "steals_per_game": 0.90, 
       "blocks_per_game": 0.42
+    }, 
+    {
+      "name": "Blake Griffin",
+      "team": "Detroit Pistons", 
+      "games_played": 46, 
+      "points_per_game": 26.5, 
+      "field_goal_percentage": 48,
+      "three_point_percentage": 36, 
+      "free_throw_percentage": 76,
+      "rebounds_per_game": 8.1,
+      "assist_per_game": 5.2,
+      "steals_per_game": 0.83, 
+      "blocks_per_game": 0.46
+    }, 
+    {
+      "name": "Andre Drummond",
+      "team": "Detroit Pistons", 
+      "games_played": 45, 
+      "points_per_game": 16.5, 
+      "field_goal_percentage": 49,
+      "three_point_percentage": 13, 
+      "free_throw_percentage": 53,
+      "rebounds_per_game": 15.0,
+      "assist_per_game": 1.2,
+      "steals_per_game": 1.58, 
+      "blocks_per_game": 1.64
+    }, 
+    {
+      "name": "Reggie Jackson",
+      "team": "Detroit Pistons", 
+      "games_played": 48, 
+      "points_per_game": 14.1, 
+      "field_goal_percentage": 39,
+      "three_point_percentage": 34, 
+      "free_throw_percentage": 86,
+      "rebounds_per_game": 2.8,
+      "assist_per_game": 4.2,
+      "steals_per_game": 0.67, 
+      "blocks_per_game": 0.13
     }
    
   ]

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -584,6 +584,45 @@
       "assist_per_game": 1.1,
       "steals_per_game": 0.92, 
       "blocks_per_game": 1.49
+    }, 
+    {
+      "name": "Josh Richardson",
+      "team": "Miami Heat", 
+      "games_played": 51, 
+      "points_per_game": 17.5, 
+      "field_goal_percentage": 40,
+      "three_point_percentage": 37, 
+      "free_throw_percentage": 86,
+      "rebounds_per_game": 3.7,
+      "assist_per_game": 3.9,
+      "steals_per_game": 1.13, 
+      "blocks_per_game": 0.48
+    },
+    {
+      "name": "Goran Dragic",
+      "team": "Miami Heat", 
+      "games_played": 14, 
+      "points_per_game": 15.3, 
+      "field_goal_percentage": 41,
+      "three_point_percentage": 31, 
+      "free_throw_percentage": 76,
+      "rebounds_per_game": 3.1,
+      "assist_per_game": 4.9,
+      "steals_per_game": 0.71, 
+      "blocks_per_game": 0.29
+    }, 
+    {
+      "name": "Dwyane Wade",
+      "team": "Miami Heat", 
+      "games_played": 39, 
+      "points_per_game": 13.8, 
+      "field_goal_percentage": 42,
+      "three_point_percentage": 32, 
+      "free_throw_percentage": 70,
+      "rebounds_per_game": 3.7,
+      "assist_per_game": 4.3,
+      "steals_per_game": 0.62, 
+      "blocks_per_game": 0.46
     }
     
    

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -77,6 +77,45 @@
       "assist_per_game": 1.4,
       "steals_per_game": 0.61, 
       "blocks_per_game": 0.35
+    }, 
+    {
+      "name": "D'Angelo Russel",
+      "team": "Brooklyn Nets", 
+      "games_played": 50, 
+      "points_per_game": 19.3, 
+      "field_goal_percentage": 44,
+      "three_point_percentage": 37, 
+      "free_throw_percentage": 81,
+      "rebounds_per_game": 3.8,
+      "assist_per_game": 6.4,
+      "steals_per_game": 1.1, 
+      "blocks_per_game": 0.28
+    }, 
+    {
+      "name": "Caris LeVert",
+      "team": "Brooklyn Nets", 
+      "games_played": 14, 
+      "points_per_game": 18.4, 
+      "field_goal_percentage": 47,
+      "three_point_percentage": 31, 
+      "free_throw_percentage": 72,
+      "rebounds_per_game": 4.3,
+      "assist_per_game": 3.7,
+      "steals_per_game": 1.2, 
+      "blocks_per_game": 0.36
+    }, 
+    {
+      "name": "Spencer Dinwiddie",
+      "team": "Brooklyn Nets", 
+      "games_played": 49, 
+      "points_per_game": 17.2, 
+      "field_goal_percentage": 46,
+      "three_point_percentage": 36, 
+      "free_throw_percentage": 80,
+      "rebounds_per_game": 2.5,
+      "assist_per_game": 5.0,
+      "steals_per_game": 0.57, 
+      "blocks_per_game": 0.22
     }
    
   ]

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -116,6 +116,45 @@
       "assist_per_game": 5.0,
       "steals_per_game": 0.57, 
       "blocks_per_game": 0.22
+    }, 
+    {
+      "name": "Kemba Walker",
+      "team": "Charlotte Hornets", 
+      "games_played": 49, 
+      "points_per_game": 24.4, 
+      "field_goal_percentage": 43,
+      "three_point_percentage": 35, 
+      "free_throw_percentage": 82,
+      "rebounds_per_game": 4.3,
+      "assist_per_game": 5.6,
+      "steals_per_game": 1.22, 
+      "blocks_per_game": 0.53
+    }, 
+    {
+      "name": "Jeremy Lamb",
+      "team": "Charlotte Hornets", 
+      "games_played": 46, 
+      "points_per_game": 15.2, 
+      "field_goal_percentage": 44,
+      "three_point_percentage": 34, 
+      "free_throw_percentage": 86,
+      "rebounds_per_game": 5.6,
+      "assist_per_game": 2.0,
+      "steals_per_game": 0.96, 
+      "blocks_per_game": 0.28
+    }, 
+    {
+      "name": "Marvin Williams",
+      "team": "Charlotte Hornets", 
+      "games_played": 48, 
+      "points_per_game": 10.1, 
+      "field_goal_percentage": 41,
+      "three_point_percentage": 37, 
+      "free_throw_percentage": 72,
+      "rebounds_per_game": 5.6,
+      "assist_per_game": 1.3,
+      "steals_per_game": 0.90, 
+      "blocks_per_game": 0.73
     }
    
   ]

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -896,6 +896,45 @@
       "assist_per_game": 2.8,
       "steals_per_game": 0.40, 
       "blocks_per_game": 0.21
+    }, 
+    {
+      "name": "Devin Booker",
+      "team": "Phoenix Suns", 
+      "games_played": 39, 
+      "points_per_game": 24.5, 
+      "field_goal_percentage": 45,
+      "three_point_percentage": 31, 
+      "free_throw_percentage": 85,
+      "rebounds_per_game": 3.6,
+      "assist_per_game": 6.7,
+      "steals_per_game": 0.90, 
+      "blocks_per_game": 0.18
+    }, 
+    {
+      "name": "TJ Warren",
+      "team": "Phoenix Suns", 
+      "games_played": 43, 
+      "points_per_game": 18.0, 
+      "field_goal_percentage": 48,
+      "three_point_percentage": 43, 
+      "free_throw_percentage": 81,
+      "rebounds_per_game": 4.0,
+      "assist_per_game": 1.5,
+      "steals_per_game": 1.19, 
+      "blocks_per_game": 0.67
+    }, 
+    {
+      "name": "Deandre Ayton",
+      "team": "Phoenix Suns", 
+      "games_played": 47, 
+      "points_per_game": 16.4, 
+      "field_goal_percentage": 59,
+      "three_point_percentage": 0, 
+      "free_throw_percentage": 77,
+      "rebounds_per_game": 10.6,
+      "assist_per_game": 2.0,
+      "steals_per_game": 0.79, 
+      "blocks_per_game": 0.98
     }
     
    

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -428,7 +428,47 @@
       "assist_per_game": 2.1,
       "steals_per_game": 0.58, 
       "blocks_per_game": 0.39
+    }, 
+    {
+      "name": "Victor Oladipo",
+      "team": "Indiana Pacers", 
+      "games_played": 36, 
+      "points_per_game": 18.8, 
+      "field_goal_percentage": 42,
+      "three_point_percentage": 34, 
+      "free_throw_percentage": 73,
+      "rebounds_per_game": 5.6,
+      "assist_per_game": 5.2,
+      "steals_per_game": 1.67, 
+      "blocks_per_game": 0.31
+    },
+    {
+      "name": "Bojan Bogdanovic",
+      "team": "Indiana Pacers", 
+      "games_played": 49, 
+      "points_per_game": 16.0, 
+      "field_goal_percentage": 48,
+      "three_point_percentage": 43, 
+      "free_throw_percentage": 83,
+      "rebounds_per_game": 4.1,
+      "assist_per_game": 1.7,
+      "steals_per_game": 0.84, 
+      "blocks_per_game": 0
+    }, 
+    {
+      "name": "Domantas Sabonis",
+      "team": "Indiana Pacers", 
+      "games_played": 47, 
+      "points_per_game": 14.7, 
+      "field_goal_percentage": 61,
+      "three_point_percentage": 78, 
+      "free_throw_percentage": 75,
+      "rebounds_per_game": 9.4,
+      "assist_per_game": 2.8,
+      "steals_per_game": 0.64, 
+      "blocks_per_game": 0.47
     }
+    
    
   ]
 }

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -1,17 +1,44 @@
 {
   "players": [
+     {
+      "name": "John Collins",
+      "team": "Atlanta Hawks", 
+      "games_played": 33, 
+      "points_per_game": 19.5, 
+      "field_goal_percentage": 59,
+      "three_point_percentage": 40, 
+      "free_throw_percentage": 73,
+      "rebounds_per_game": 10.0,
+      "assist_per_game": 2.3,
+      "steals_per_game": 0.30, 
+      "blocks_per_game": 0.33
+    }, 
     {
-      "name": 
-      "team": 
-      "games_played":
-      "points_per_game": 
-      "field_goal_percentage": 
-      "three_point_percentage": 
-      "free_throw_percentage":
-      "rebounds_per_game": 
-      "assist_per_game": 
-      "steals_per_game": 
-      "blocks_per_game": 
+      "name": "Trae Young",
+      "team": "Atlanta Hawks", 
+      "games_played": 49, 
+      "points_per_game": 16.4, 
+      "field_goal_percentage": 40,
+      "three_point_percentage": 29, 
+      "free_throw_percentage": 81,
+      "rebounds_per_game": 3.2,
+      "assist_per_game": 7.3,
+      "steals_per_game": 0.88, 
+      "blocks_per_game": 0.24
+    }, 
+    {
+      "name": "Kent Bazemore",
+      "team": "Atlanta Hawks", 
+      "games_played": 35, 
+      "points_per_game": 14.0, 
+      "field_goal_percentage": 44,
+      "three_point_percentage": 33, 
+      "free_throw_percentage": 75,
+      "rebounds_per_game": 4.0,
+      "assist_per_game": 2.6,
+      "steals_per_game": 1.7, 
+      "blocks_per_game": 0.91
     }
+   
   ]
 }

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -389,6 +389,45 @@
       "assist_per_game": 2.0,
       "steals_per_game": 1.18, 
       "blocks_per_game": 0.64
+    }, 
+    {
+      "name": "James Harden",
+      "team": "Houston Rockets", 
+      "games_played": 46, 
+      "points_per_game": 36.3, 
+      "field_goal_percentage": 44,
+      "three_point_percentage": 36, 
+      "free_throw_percentage": 87,
+      "rebounds_per_game": 6.6,
+      "assist_per_game": 8.2,
+      "steals_per_game": 2.04, 
+      "blocks_per_game": 0.72
+    }, 
+    {
+      "name": "Clint Capela",
+      "team": "Houston Rockets", 
+      "games_played": 42, 
+      "points_per_game": 17.6, 
+      "field_goal_percentage": 63,
+      "three_point_percentage": 0, 
+      "free_throw_percentage": 63,
+      "rebounds_per_game": 12.6,
+      "assist_per_game": 1.5,
+      "steals_per_game": 0.60, 
+      "blocks_per_game": 1.83
+    }, 
+    {
+      "name": "Eric Gordon",
+      "team": "Houston Rockets", 
+      "games_played": 38, 
+      "points_per_game": 16.3, 
+      "field_goal_percentage": 38,
+      "three_point_percentage": 31, 
+      "free_throw_percentage": 80,
+      "rebounds_per_game": 2.7,
+      "assist_per_game": 2.1,
+      "steals_per_game": 0.58, 
+      "blocks_per_game": 0.39
     }
    
   ]

--- a/nba-players-data.json
+++ b/nba-players-data.json
@@ -38,6 +38,45 @@
       "assist_per_game": 2.6,
       "steals_per_game": 1.7, 
       "blocks_per_game": 0.91
+    }, 
+    {
+      "name": "Kyrie Irving",
+      "team": "Boston Celtics", 
+      "games_played": 43, 
+      "points_per_game": 23.7, 
+      "field_goal_percentage": 49,
+      "three_point_percentage": 41, 
+      "free_throw_percentage": 85,
+      "rebounds_per_game": 4.8,
+      "assist_per_game": 6.9,
+      "steals_per_game": 1.7, 
+      "blocks_per_game": 0.47
+    }, 
+    {
+      "name": "Jayson Tatum",
+      "team": "Boston Celtics", 
+      "games_played": 50, 
+      "points_per_game": 16.2, 
+      "field_goal_percentage": 44,
+      "three_point_percentage": 38, 
+      "free_throw_percentage": 86,
+      "rebounds_per_game": 6.2,
+      "assist_per_game": 1.8,
+      "steals_per_game": 1.0, 
+      "blocks_per_game": 0.78
+    }, 
+    {
+      "name": "Marcus Moris",
+      "team": "Boston Celtics", 
+      "games_played": 46, 
+      "points_per_game": 14.6, 
+      "field_goal_percentage": 47,
+      "three_point_percentage": 42, 
+      "free_throw_percentage": 87,
+      "rebounds_per_game": 6.1,
+      "assist_per_game": 1.4,
+      "steals_per_game": 0.61, 
+      "blocks_per_game": 0.35
     }
    
   ]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "byob",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Dhanciles/byob.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/Dhanciles/byob/issues"
+  },
+  "homepage": "https://github.com/Dhanciles/byob#readme"
+}


### PR DESCRIPTION
PR Addresses Issue #1:
- dataset for with top 3 leading scorers from each team have been implemented. 

- data includes: `name, game_played, team, points_per_game, field_goal_percentage, 
three_point_percentage, free_throw_percentage, rebounds_per_game, assist_per_game, steals_per_game, blocks_per_game`

- dataset lives in `json` file
